### PR TITLE
Channel bar adjustments

### DIFF
--- a/src/app/components/ChannelList/ChannelRow.less
+++ b/src/app/components/ChannelList/ChannelRow.less
@@ -40,19 +40,19 @@
       opacity: 0.8;
     }
 
-    &-progress-bar-background {
+    &-progress {
       width: 100%;
-      height: 5px;
-      background-color: #f1f1f1!important;
-      border-radius: 4px;
-      opacity: 0.9;
-      margin-top: 2px;
+      height: 4px;
+      background-color: rgba(#000, 0.04);
+      border-radius: 2px;
+      margin-top: 0.4rem;
+
+      &-inner {
+        height: 100%;
+        background-color: rgba(#000, 0.25);
+        border-radius: 2px;
+        opacity: 0.7;
+      }
     }
-  
-  &-progress-bar {
-      height: 5px;
-      background-color: @primary-color !important;
-      border-radius: 4px;
   }
-}
 }

--- a/src/app/components/ChannelList/ChannelRow.tsx
+++ b/src/app/components/ChannelList/ChannelRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import BN from 'bn.js';
 import classnames from 'classnames';
 import Identicon from 'components/Identicon';
 import Unit from 'components/Unit';
@@ -13,6 +14,11 @@ interface Props {
 export default class ChannelRow extends React.Component<Props> {
   render() {
     const { channel, onClick } = this.props;
+    const capacityPct = new BN(channel.local_balance)
+      .muln(100)
+      .div(new BN(channel.capacity))
+      .toString();
+
     return (
       <div
         className={classnames("ChannelRow", onClick && 'is-clickable')}
@@ -34,8 +40,8 @@ export default class ChannelRow extends React.Component<Props> {
             {' / '}
             <Unit value={channel.capacity} />
           </div>
-          <div className="ChannelRow-info-progress-bar-background">
-            <div className="ChannelRow-info-progress-bar" style={{width: Math.round(parseFloat(channel.local_balance) / parseFloat(channel.capacity) * 100) + '%'}}></div>
+          <div className="ChannelRow-info-progress">
+            <div className="ChannelRow-info-progress-inner" style={{ width: `${capacityPct}%` }}/>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This makes some adjustments to https://github.com/wbobeirne/joule-extension/pull/80:

* Changes classnames to be SuitCSS compliant
* Changes some units to use `rem`s instead of `px`.
* Changes parseFloats to use bn.js, since satoshis (while unlikely) can exceed 32 bit floats
* Change progress bar colors to reduce visual overload. This is purely subjective, but I felt it was a little harder to parse the main screen with so much primary color all at once.

Here's what it looks like now:

<img width="422" alt="screen shot 2018-12-15 at 12 39 22 pm" src="https://user-images.githubusercontent.com/649992/50045791-28580780-0067-11e9-9148-6031d0042824.png">

If you're OK with these changes, feel free to merge in and I'll merge into the main Joule repo. If there are any changes you didn't like, just let me know and we can work them out!